### PR TITLE
Bugfix: node14 vfile issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "accessibility-statement-generator",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A CLI with prompts to facilitate the creation of PSBAR compliant Accessibility Statements.",
   "main": "index.js",
   "bin": "./asg",
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/plopfile.js
+++ b/plopfile.js
@@ -28,7 +28,7 @@ const markdown = (answers, config, plop) => {
   return readFile(config.source)
     .then(render)
     .then(report)
-    .then(writeFile.bind(null, fileDestPath))
+    .then(vfile => writeFile(fileDestPath, vfile.contents))
     .then(() => getRelativeToBasePath(fileDestPath, plop));
 };
 


### PR DESCRIPTION
This fixes the second problem described in issue #9 

For some reason the implicit `.toString` method of `VFile` doesn't work in Node v14 the same way it did in v12, so explicitly use raw `VFile.contents` instead to guarantee a writable value.